### PR TITLE
create singleton only when module is enabled

### DIFF
--- a/code/Model/Observer.php
+++ b/code/Model/Observer.php
@@ -82,11 +82,11 @@ class Danslo_ApiImport_Model_Observer
     protected function _indexProductRewrites(&$productIds)
     {
         // Only generate URL rewrites when this module is enabled.
-        $indexer = Mage::getResourceSingleton('ecomdev_urlrewrite/indexer');
-        if ($indexer) {
-            return $indexer->updateProductRewrites($productIds);
+        if(!Mage::helper('core')->isModuleEnabled('EcomDev_UrlRewrite')) {
+            return $this;
         }
-        return $this;
+
+        return Mage::getResourceSingleton('ecomdev_urlrewrite/indexer')->updateProductRewrites($productIds);
     }
 
     /**
@@ -98,11 +98,11 @@ class Danslo_ApiImport_Model_Observer
     protected function _indexCategoryRewrites(&$categoryIds)
     {
         // Only generate URL rewrites when this module is enabled.
-        $indexer = Mage::getResourceSingleton('ecomdev_urlrewrite/indexer');
-        if ($indexer) {
-            return $indexer->updateCategoryRewrites($categoryIds);
+        if(!Mage::helper('core')->isModuleEnabled('EcomDev_UrlRewrite')) {
+            return $this;
         }
-        return $this;
+
+        return Mage::getResourceSingleton('ecomdev_urlrewrite/indexer')->updateCategoryRewrites($categoryIds);
     }
 
     /**


### PR DESCRIPTION
Magento has a bug, where an exception is thrown, when you try to load a non existant singleton for the 2nd time.

The first time, the registry key is created with the value false.

The 2nd time, it will try to create the key again (because the condition is only if (!self::registry($registryKey)), but should be checking if the key is set) and raise an Exception.
