### PR TITLE
Fix ImportExport problem with new destructor of Varien_Image_Adapter_Gd2 in 1.9.2.x

### DIFF
--- a/code/Helper/Catalog/Image.php
+++ b/code/Helper/Catalog/Image.php
@@ -1,0 +1,23 @@
+<?php
+
+class Danslo_ApiImport_Helper_Catalog_Image extends Mage_Catalog_Helper_Image
+{
+    /**
+     * Check - is this file an image
+     *
+     * @param string $filePath
+     * @return bool
+     * @throws Mage_Core_Exception
+     */
+    public function validateUploadFile($filePath) {
+        if (!getimagesize($filePath)) {
+            Mage::throwException($this->__('Disallowed file type.'));
+        }
+
+        $_processor = new Danslo_ApiImport_Model_Image($filePath);
+        $hasMimeType = $_processor->getMimeType() !== null;
+        unset($_processor);
+
+        return $hasMimeType;
+    }
+}

--- a/code/Model/Image.php
+++ b/code/Model/Image.php
@@ -1,0 +1,16 @@
+<?php
+
+class Danslo_ApiImport_Model_Image extends Varien_Image
+{
+    /**
+     * Destruct
+     */
+    public function __destruct()
+    {
+        $adpater = $this->_getAdapter();
+
+        if ($adpater instanceof Varien_Image_Adapter_Gd2) {
+            $adpater->destruct();
+        }
+    }
+}

--- a/code/Model/Import/Entity/Product.php
+++ b/code/Model/Import/Entity/Product.php
@@ -295,4 +295,28 @@ class Danslo_ApiImport_Model_Import_Entity_Product
         return $this;
     }
 
+    /**
+     * Returns an object for upload a media files
+     */
+    protected function _getUploader()
+    {
+        if (is_null($this->_fileUploader)) {
+            $this->_fileUploader = new Danslo_ApiImport_Model_Import_Uploader();
+
+            $this->_fileUploader->init();
+
+            $tmpDir     = Mage::getConfig()->getOptions()->getMediaDir() . '/import';
+            $destDir    = Mage::getConfig()->getOptions()->getMediaDir() . '/catalog/product';
+            if (!is_writable($destDir)) {
+                @mkdir($destDir, 0777, true);
+            }
+            if (!$this->_fileUploader->setTmpDir($tmpDir)) {
+                Mage::throwException("File directory '{$tmpDir}' is not readable.");
+            }
+            if (!$this->_fileUploader->setDestDir($destDir)) {
+                Mage::throwException("File directory '{$destDir}' is not writable.");
+            }
+        }
+        return $this->_fileUploader;
+    }
 }

--- a/code/Model/Import/Uploader.php
+++ b/code/Model/Import/Uploader.php
@@ -1,0 +1,20 @@
+<?php
+
+class Danslo_ApiImport_Model_Import_Uploader extends Mage_ImportExport_Model_Import_Uploader
+{
+    /**
+     * Initiate uploader default settings
+     */
+    public function init()
+    {
+        parent::init();
+
+        if (version_compare(Mage::getVersion(), '1.9.2.0') >= 0) {
+            $this->addValidateCallback(
+                'catalog_product_image',
+                Mage::helper('api_import/catalog_image'),
+                'validateUploadFile'
+            );
+        }
+    }
+}


### PR DESCRIPTION
http://magento.stackexchange.com/questions/79672/importexport-problem-with-new-destructor-of-varien-image-adapter-gd2-in-1-9-2-0